### PR TITLE
wrap ExpressionStatement into a BlockStatement and avoid string manipulations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,36 @@
 //jshint node:true, eqnull:true
 'use strict';
-var wrapWithBraces = function(node) {
-    var newToken = {
-        type: 'BlockStatement' // can be anything (not used internally)
+
+var tk = require('rocambole-token');
+
+var wrapWithBraces = function(node, prop) {
+    var old = node[prop];
+    var block = {
+        type: 'BlockStatement',
+        parent: old.parent,
+        root: old.root,
+        body: [ old ],
+        startToken: tk.before(old.startToken, {
+            type: 'Punctuator',
+            value: '{'
+        }),
+        endToken: tk.after(old.endToken, {
+            type: 'Punctuator',
+            value: '}'
+        })
     };
-    newToken.value = '{ ' + node.toString() + ' }';
-    // update linked list references
-    if (node.startToken.prev) {
-        node.startToken.prev.next = newToken;
-        newToken.prev = node.startToken.prev;
-    }
-    if (node.endToken.next) {
-        node.endToken.next.prev = newToken;
-        newToken.next = node.endToken.next;
-    }
-    node.startToken = node.endToken = newToken;
+    old.parent = block;
+    node[prop] = block;
 };
 
 var checkConditionals = function(node) {
     //replace regular conditionals
     if (node.consequent.type === 'ExpressionStatement') {
-        wrapWithBraces(node.consequent);
+        wrapWithBraces(node, 'consequent');
     }
     //replace else alternate conditional
     if (node.alternate && node.alternate.type === 'ExpressionStatement') {
-        wrapWithBraces(node.alternate);
+        wrapWithBraces(node, 'alternate');
     }
 };
 
@@ -36,7 +42,7 @@ exports.nodeBefore = function(node) {
     //handle loops
     if (node.type === 'WhileStatement' || node.type === 'DoWhileStatement' || node.type === 'ForStatement') {
         if (node.body.type === 'ExpressionStatement') {
-            wrapWithBraces(node.body);
+            wrapWithBraces(node, 'body');
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "chai": "^1.9.1",
     "esformatter": "^0.3.2",
     "mocha": "^1.20.1"
+  },
+  "dependencies": {
+    "rocambole-token": "^1.2.1"
   }
 }

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -21,19 +21,19 @@ describe('esformatter-braces', function () {
         it('should test an if statement', function () {
             var str = 'if (a) b();';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('if (a) { b(); }');
+            expect(output).to.be.eql('if (a) {\n  b();\n}');
         });
 
         it('should test an if / else conditional', function () {
             var str = 'if (a) b(); else c();';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('if (a) { b(); } else { c(); }');
+            expect(output).to.be.eql('if (a) {\n  b();\n} else {\n  c();\n}');
         });
 
         it('should test an if / else if / else conditionals', function () {
             var str = 'if (a) b(); else if (w) c(); else y();';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('if (a) { b(); } else if (w)\n{ c(); } else { y(); }');
+            expect(output).to.be.eql('if (a) {\n  b();\n} else if (w) {\n  c();\n} else {\n  y();\n}');
         });
     });
 
@@ -41,19 +41,19 @@ describe('esformatter-braces', function () {
         it('should test a basic while loop', function () {
             var str = 'while (true) a();';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('while (true) { a(); }');
+            expect(output).to.be.eql('while (true) {\n  a();\n}');
         });
 
         it('should test a basic for loop', function () {
             var str = 'for (var i = 0; i < 10; i++) a();';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('for (var i = 0; i < 10; i++) { a(); }');
+            expect(output).to.be.eql('for (var i = 0; i < 10; i++) {\n  a();\n}');
         });
 
         it('should test a do while loop', function () {
             var str = 'do a(); while (true);';
             var output = esformatter.format(str);
-            expect(output).to.be.eql('do { a(); } while (true);');
+            expect(output).to.be.eql('do {\n  a();\n} while (true);');
         });
     });
 

--- a/test/expected/basic.js
+++ b/test/expected/basic.js
@@ -1,2 +1,3 @@
-if (theSkyIsBlue)
-{ stareAtItForAWhile(); }
+if (theSkyIsBlue) {
+  stareAtItForAWhile();
+}


### PR DESCRIPTION
this behavior is better since it will allow other plugins and esformatter itself to format each individual node/token.

notice that now esformatter adds line breaks and indentation for the `ExpressionStatement`.
