### PR TITLE
Fix `BlockStatement` typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var wrapWithBraces = function (node, prop) {
 
 var checkConditionals = function (node) {
     //replace regular conditionals
-    if (node.consequent.type !== 'Blockstatement') {
+    if (node.consequent.type !== 'BlockStatement') {
         wrapWithBraces(node, 'consequent');
     }
     //replace else alternate conditional

--- a/test/expected/donothing.js
+++ b/test/expected/donothing.js
@@ -1,0 +1,7 @@
+if (theSkyIsBlue) {
+  stareAtItForAWhile();
+}
+
+if (theSkyIsBlue) {
+  stareAtItForAWhile()
+}

--- a/test/fixtures/donothing.js
+++ b/test/fixtures/donothing.js
@@ -1,0 +1,5 @@
+if (theSkyIsBlue) { stareAtItForAWhile(); }
+
+if (theSkyIsBlue) {
+    stareAtItForAWhile()
+}


### PR DESCRIPTION
It wrapped a statement with braces even if it wasn't necessary.

I have also added `donothing` fixture, to avoid this type of error.
